### PR TITLE
Block CharacterSync 2.0.0.4

### DIFF
--- a/UIRes/bannedplugin.json
+++ b/UIRes/bannedplugin.json
@@ -207,5 +207,10 @@
     "Name": "EngageTimer",
     "AssemblyVersion": "2.2.0.0",
     "Reason": "Crashes"
+  },
+  {
+    "Name": "Dalamud.CharacterSync",
+    "AssemblyVersion": "2.0.0.4",
+    "Reason": "Too many reports of users' data getting blanked out. Bypass the ban at your own risk. Take backups first before continued use."
   }
 ]

--- a/asset.json
+++ b/asset.json
@@ -1,5 +1,5 @@
 {
-   "Version":73,
+   "Version":74,
    "Assets":[
       {
          "Url":"https://goatcorp.github.io/DalamudAssets/UIRes/serveropcode.json",


### PR DESCRIPTION
Too many users keep reporting issues where this plugin is failing and wiping their data. 

Ban message includes basic disclaimer if they bypass/ignore  the block.