### PR TITLE
Add extra opcodes to serveropcode.json

### DIFF
--- a/UIRes/serveropcode.json
+++ b/UIRes/serveropcode.json
@@ -10,5 +10,9 @@
   "AirshipTimers": 797,
   "SubmarineTimers": 567,
   "AirshipStatusList": 543,
-  "SubmarineStatusList": 913
+  "SubmarineStatusList": 913,
+  "RetainerInformation": 992,
+  "ItemMarketBoardInfo": 706,
+  "ContainerInfo": 140,
+  "InventoryActionAck": 269
 }

--- a/asset.json
+++ b/asset.json
@@ -1,5 +1,5 @@
 {
-   "Version":104,
+   "Version":105,
    "Assets":[
       {
          "Url":"https://raw.githubusercontent.com/goatcorp/DalamudAssets/master/UIRes/serveropcode.json",


### PR DESCRIPTION
Had a chat with Franz and it sounds like this might be a smarter way to use keep these opcodes updated at least until I can remove all reliance on them. Was using FFXIVOpcodes before but having it baked into dalamud would certainly make things easier.
I wasn't sure if I should update the asset.json file so I left that alone.