### PR TITLE
6.15 OpCodes (corrected)

### DIFF
--- a/UIRes/serveropcode.json
+++ b/UIRes/serveropcode.json
@@ -1,18 +1,19 @@
 {
-  "CfNotifyPop": 167,
-  "MarketTaxRates": 396,
-  "MarketBoardItemRequestStart": 139,
-  "MarketBoardOfferings": 297,
-  "MarketBoardHistory": 765,
-  "MarketBoardPurchase": 559,
+  "AssetGameVersion": "2022.05.27.0000.0000"
   "ActorControlSelf": 776,
   "HousingWardInfo": 898,
+  "ContainerInfo": 258,
+  "MarketBoardItemRequestStart": 139,
+  "MarketBoardHistory": 765,
+  "MarketBoardOfferings": 297,
+  "MarketBoardPurchase": 559,
+  "InventoryActionAck": 950,
+  "MarketTaxRates": 148,
+  "RetainerInformation": 437,
+  "ItemMarketBoardInfo": 405,
+  "CfNotifyPop": 167,
   "AirshipTimers": 797,
   "SubmarineTimers": 567,
   "AirshipStatusList": 543,
-  "SubmarineStatusList": 913,
-  "RetainerInformation": 992,
-  "ItemMarketBoardInfo": 706,
-  "ContainerInfo": 140,
-  "InventoryActionAck": 269
+  "SubmarineStatusList": 913
 }

--- a/asset.json
+++ b/asset.json
@@ -1,5 +1,5 @@
 {
-   "Version":105,
+   "Version":106,
    "Assets":[
       {
          "Url":"https://raw.githubusercontent.com/goatcorp/DalamudAssets/master/UIRes/serveropcode.json",


### PR DESCRIPTION
Ran through OpcodeWizard and rechecked all the opcodes now that it's operational again.

Also put opcodes in the same order as opcode wizard for easier reading experiences.

I've added the game version this matches against so that anyone who wants to compare asset version to game version can now check if they match. This field will be updated to ffxivgame.ver as needed.

*Don't merge until someone else can verify these look look OK.