### PR TITLE
force playertrack update

### DIFF
--- a/UIRes/bannedplugin.json
+++ b/UIRes/bannedplugin.json
@@ -322,5 +322,10 @@
     "Name": "Tourist",
     "AssemblyVersion": "1.2.9",
     "Reason": "Temporarily blocked due to user reported crashes. Please wait for the developer to update it."
+  },
+  {
+    "Name": "PlayerTrack",
+    "AssemblyVersion": "2.6.6.0",
+    "Reason": "Please install an update for this plugin to continue using it."
   }
 ]

--- a/asset.json
+++ b/asset.json
@@ -1,5 +1,5 @@
 {
-   "Version":122,
+   "Version":123,
    "Assets":[
       {
          "Url":"https://raw.githubusercontent.com/goatcorp/DalamudAssets/master/UIRes/serveropcode.json",


### PR DESCRIPTION
Update to ban old PlayerTrack versions using the old API so I can take it down without impacting users.