### PR TITLE
Update ContainerInfo opcode

### DIFF
--- a/UIRes/serveropcode.json
+++ b/UIRes/serveropcode.json
@@ -1,7 +1,7 @@
 {
   "ActorControlSelf": 568,
   "HousingWardInfo": 723,
-  "ContainerInfo": 593,
+  "ContainerInfo": 217,
   "MarketBoardItemRequestStart": 963,
   "MarketBoardHistory": 876,
   "MarketBoardOfferings": 624,

--- a/asset.json
+++ b/asset.json
@@ -1,5 +1,5 @@
 {
-   "Version":129,
+   "Version":130,
    "Assets":[
       {
          "Url":"https://raw.githubusercontent.com/goatcorp/DalamudAssets/master/UIRes/serveropcode.json",


### PR DESCRIPTION
It appears the ContainerInfo opcode is currently pointing at the CN opcode(593) and not the Global opcode(217).
PR fixes that and bumps the version