### PR TITLE
Block KikoGuide v1.5.0.2

### DIFF
--- a/UIRes/bannedplugin.json
+++ b/UIRes/bannedplugin.json
@@ -337,5 +337,10 @@
     "Name": "DeepDungeonDex",
     "AssemblyVersion": "2.0.1.0",
     "Reason": "Causes a game crash under certain conditions. Please install an update for this plugin to continue using it."
+  },
+  {
+    "Name": "KikoGuide",
+    "AssemblyVersion": "1.5.0.2",
+    "Reason": "Causes configuration saving problems when certain integrations are enabled. Please wait for an update to continue using this plugin
   }
 ]

--- a/asset.json
+++ b/asset.json
@@ -1,5 +1,5 @@
 {
-   "Version":131,
+   "Version":132,
    "Assets":[
       {
          "Url":"https://raw.githubusercontent.com/goatcorp/DalamudAssets/master/UIRes/serveropcode.json",


### PR DESCRIPTION
The IPC implementation of Kikoguide v1.5.0.2 causes all plugins to be unable to save their configurations under certain conditions. As a fix for this plugin may be a little while out still I think its best to ban it. 