### PR TITLE
Update bannedplugin.json

### DIFF
--- a/UIRes/bannedplugin.json
+++ b/UIRes/bannedplugin.json
@@ -25,7 +25,7 @@
   },
   {
     "Name": "DamageInfoPlugin",
-    "AssemblyVersion": "1.3.7.1"
+    "AssemblyVersion": "2.3.0.1"
   },
   {
     "Name": "TextToTalk",
@@ -333,5 +333,13 @@
   {
     "Name": "BlueMageHelper",
     "AssemblyVersion": "2.0.5.1"
+  },
+  {
+    "Name": "ItemVendorLocation",
+    "AssemblyVersion": "2.2.0.1"
+  },
+  {
+    "Name": "HighFpsPhysicsPlugin",
+    "AssemblyVersion": "7.1.0"
   }
 ]


### PR DESCRIPTION
Blocks the following old versions of plugins:
- DamageInfoPlugin 2.3.0.1
- ItemVendorLocation 2.2.0.1
- HighFpsPhysicsPlugin 7.1.0