### PR TITLE
Update bannedplugin.json

### DIFF
--- a/UIRes/bannedplugin.json
+++ b/UIRes/bannedplugin.json
@@ -185,7 +185,7 @@
   },
   {
     "Name": "PlayerTrack",
-    "AssemblyVersion": "2.6.6.0"
+    "AssemblyVersion": "2.7.0.0"
   },
   {
     "Name": "CharacterPanelRefined",
@@ -413,5 +413,13 @@
   {
     "Name": "Namingway",
     "AssemblyVersion": "1.1.9.0"
+  },
+  {
+    "Name": "ActionTimeline",
+    "AssemblyVersion": "1.1.0.0"
+  },
+  {
+    "Name": "ReadyCheckHelper",
+    "AssemblyVersion": "1.0.4.2"
   }
 ]


### PR DESCRIPTION
Bans:
ActionTimeline v1.1.0.0
PlayerTrack v2.7.0.0
ReadyCheckHelper v1.0.4.2

All of the above are pre-6.4 versions that may have been missed in testing, and have since been updated. May be the cause for crash on character login.