### PR TITLE
Ban CurrencyTracker v1.1.1.2

### DIFF
--- a/UIRes/bannedplugin.json
+++ b/UIRes/bannedplugin.json
@@ -436,6 +436,11 @@
     "AssemblyVersion": "2.5.0.0"
   },
   {
+    "Name": "CurrencyTracker",
+    "AssemblyVersion": "1.1.1.2",
+    "Reason": "UI draw has unclosed BeginPopup() calls, causes game to CTD"
+  }
+  {
     "Name": "B778B7FD16CA72AC1EA7A0F28A099D46948B4A732B6F08F12E4C5861041FE87B",
     "AssemblyVersion": "1.2.0.3"
   }

--- a/UIRes/bannedplugin.json
+++ b/UIRes/bannedplugin.json
@@ -438,8 +438,8 @@
   {
     "Name": "CurrencyTracker",
     "AssemblyVersion": "1.1.1.2",
-    "Reason": "UI draw has unclosed BeginPopup() calls, causes game to CTD"
-  }
+    "Reason": "crashes when UI open for ten minutes"
+  },
   {
     "Name": "B778B7FD16CA72AC1EA7A0F28A099D46948B4A732B6F08F12E4C5861041FE87B",
     "AssemblyVersion": "1.2.0.3"


### PR DESCRIPTION
UI draw has unclosed `ImGui.BeginPopup()` calls, which causes the game to CTD