### PR TITLE
Ban Redirect 1.2.2.0 and below

### DIFF
--- a/UIRes/bannedplugin.json
+++ b/UIRes/bannedplugin.json
@@ -356,7 +356,7 @@
   },
   {
     "Name": "Redirect",
-    "AssemblyVersion": "1.2.1.4"
+    "AssemblyVersion": "1.2.2.0"
   },
   {
     "Name": "SoundSetter",


### PR DESCRIPTION
- Change in XIVClientStructs caused unexpected behavior preventing Sprint from working using default settings