### PR TITLE
Update bannedplugin.json

### DIFF
--- a/UIRes/bannedplugin.json
+++ b/UIRes/bannedplugin.json
@@ -480,8 +480,8 @@
   },
   {
     "Name": "CurrencyTracker",
-    "AssemblyVersion": "1.3.2.1",
-    "Reason": "causees game crash and data loss"
+    "AssemblyVersion": "1.3.4.0",
+    "Reason": "causes game crash"
   },
   {
     "Name": "DutyTracker",


### PR DESCRIPTION
Currency Tracker 1.3.4.0 causes game crash.
Fixed the issue in 1.3.4.1 (https://github.com/goatcorp/DalamudPluginsD17/pull/3120)