### PR TITLE
Update bannedplugin.json

### DIFF
--- a/UIRes/bannedplugin.json
+++ b/UIRes/bannedplugin.json
@@ -464,7 +464,7 @@
   },
   {
     "Name": "TrackyTrack",
-    "AssemblyVersion": "1.3.0.8"
+    "AssemblyVersion": "1.4.0.0"
   },
   {
     "Name": "rtyping",


### PR DESCRIPTION
GameInventory returned unexpected results which made alot of the data send to my database invalid, so banning this version.

New version with a fix is PRed to DP17: https://github.com/goatcorp/DalamudPluginsD17/pull/3143