### PR TITLE
Ban GoodFriend v3.2.0.0

### DIFF
--- a/UIRes/bannedplugin.json
+++ b/UIRes/bannedplugin.json
@@ -395,7 +395,8 @@
   },
   {
     "Name": "GoodFriend",
-    "AssemblyVersion": "1.4.6.0"
+    "AssemblyVersion": "3.2.0.0",
+    "Reason": "Update the plugin to continue using GoodFriend"
   },
   {
     "Name": "Wholist",


### PR DESCRIPTION
Clients at v3.2.0.0 and below cannot actually make use of any of the plugin's features and continually fail to connect generating log spam client-side and a bunch of useless attempts server-side.