### PR TITLE
Remove trailing ,

### DIFF
--- a/UIRes/bannedplugin.json
+++ b/UIRes/bannedplugin.json
@@ -496,6 +496,6 @@
   },
   {
     "Name": "E0BAD217DCA48D9F3E1210B44AE5570DEB174FDAF1774A231F4B29E0F2B0A396",
-    "AssemblyVersion": "1.0.0.13",
+    "AssemblyVersion": "1.0.0.13"
   }
 ]


### PR DESCRIPTION
Doesn't ban any plugins, simply removes a trailing , that breaks some JSON parsers