### PR TITLE
Move GoodFriend ban to 3.3.2.0 and before

### DIFF
--- a/UIRes/bannedplugin.json
+++ b/UIRes/bannedplugin.json
@@ -395,7 +395,7 @@
   },
   {
     "Name": "GoodFriend",
-    "AssemblyVersion": "3.2.0.0",
+    "AssemblyVersion": "3.3.2.0",
     "Reason": "Update the plugin to continue using GoodFriend"
   },
   {


### PR DESCRIPTION
GoodFriend versions below v3.3.3.0 are no longer supported server-side and I get a sizeable chunk of requests from users who haven't updated in nearly 2 months so I'd like to force clients to update with a ban.