### PR TITLE
Ban OrangeGuidanceTomestone 1.8.2.0

### DIFF
--- a/UIRes/bannedplugin.json
+++ b/UIRes/bannedplugin.json
@@ -232,7 +232,7 @@
   },
   {
     "Name": "OrangeGuidanceTomestone",
-    "AssemblyVersion": "1.6.3.0"
+    "AssemblyVersion": "1.8.2.0"
   },
   {
     "Name": "E612C21D61F2AF12044F1D4E52E3249814128CDC6086D6EFB66449279F3D5496",


### PR DESCRIPTION
@anna-is-cute Looks like this is causing crashes inside VFX hooks when opening random windows. I'll block it out for now until you can have a look.

```
at FFXIVClientStructs.STD.Helper.IStaticEncoding.System.get_Encoding()
at OrangeGuidanceTomestone.MiniPenumbra.VfxReplacer.ReadSqPackDetour(Void* resourceManager, SeFileDescriptor* fileDescriptor, Int32 priority, Boolean isSync)


Exception Info #0
Address: E0434352
Flags: 1
Address: 7FFE719BBA99
Parameters: FFFFFFFF80131515, 0, 0, 0, 7FFE13C00000
Call Stack
{
[0] KERNELBASE.dll+2BA99 (RaiseException+0x69)
[1] KERNELBASE.dll+2BA99 (RaiseException+0x69)
[2] coreclr.dll+FA3F7 (coreclr_execute_assembly+0x1E967)
[3] coreclr.dll+F9B49 (coreclr_execute_assembly+0x1E0B9)
[4] 7FFDB6BDBA2F
[5] 1D9F700ED30
[6] 1D9F700EDB0
[7] 1D9F700ED18
[8] 28
[9] 1D9F6E91128
[10] 1D9F6E91398
}

Registers
{
RAX: 293F4FF228 [7FFE00020220]
RBX: 1D9F700ED30 [7FFDB75DB7E0]
RCX: 7FFDB4094000 [coreclr.dll+3C9C90 (coreclr_shutdown+0xF4D0)]
RDX: 20
R8: 7FFD00000000
R9: System.Private.CoreLib.dll+A4CE9A [120202000A010020]
R10: 1D9D8F89310 [coreclr.dll+3C88A8 (coreclr_shutdown+0xE0E8)]
R11: 293F4FEEE0 [E0434352]
R12: 4000
R13: 21A7A9B6840 [ffxiv_dx11.exe+1EB9910 (vtbl_Client::System::File::FileThread)]
R14: 1
R15: E0434352
RSI: 5
RDI: 293F4FF7B8 [FFFFFFFF80131515]
RBP: 293F4FF9B0 [21A7A9B6840]
RSP: 293F4FF620 [1D9F700ED30]
RIP: KERNELBASE.dll+2BA99 (RaiseException+0x69)
}

Stack
{
[RSP+0] 1D9F700ED30 [7FFDB75DB7E0]
[RSP+8] 1D9F700ED30 [7FFDB75DB7E0]
[RSP+10] 5
[RSP+18] 293F4FF6C0 [1100000000]
[RSP+20] 1E0434352
[RSP+28] 0
[RSP+30] KERNELBASE.dll+2BA99 (RaiseException+0x69)
[RSP+38] 1D900000005
[RSP+40] FFFFFFFF80131515
[RSP+48] 0
[RSP+50] 0
[RSP+58] 0
[RSP+60] coreclr.dll+0 [300905A4D]
[RSP+68] System.Private.CoreLib.dll+399B59 [5E5B48C48348C78B]
[RSP+70] 293F4FF670
[RSP+78] 1D9DCD74E58 [7FFDB4D96CB8]
}
```