### PR TITLE
Block previous version of BetterMountRoulette

### DIFF
--- a/UIRes/bannedplugin.json
+++ b/UIRes/bannedplugin.json
@@ -359,7 +359,7 @@
   },
   {
     "Name": "BetterMountRoulette",
-    "AssemblyVersion": "1.2.0.13"
+    "AssemblyVersion": "1.5.0.18"
   },
   {
     "Name": "Honorific",


### PR DESCRIPTION
Blocks 1.5.0.18 and older as it causes issues when trying to update to 1.5.0.19.