### PR TITLE
Ban Old Tracky Version

### DIFF
--- a/UIRes/bannedplugin.json
+++ b/UIRes/bannedplugin.json
@@ -371,7 +371,7 @@
   },
   {
     "Name": "TrackyTrack",
-    "AssemblyVersion": "1.5.2.2"
+    "AssemblyVersion": "1.5.5.2"
   },
   {
     "Name": "rtyping",


### PR DESCRIPTION
1.5.5.3 and a previous version removed some data that was getting uploaded to the DB
Banning all older versions which still trigger the uploads