### PR TITLE
Ban [REDACTED] v1.0.0.16

### DIFF
--- a/UIRes/bannedplugin.json
+++ b/UIRes/bannedplugin.json
@@ -473,5 +473,10 @@
     "Name": "CollectableCalculator",
     "AssemblyVersion": "4.0",
     "Reason": "Causing crashes. Will return when checked and updated."
+  },
+  {
+    "Name": "1E75B0956B4E2913C62C5441F292FAC7D261D3980EA71624D3644A8EBDFEE7B8",
+    "AssemblyVersion": "1.0.0.16",
+    "Reason": "Wrong opcodes leading to incorrect packet suppression server-side."
   }
 ]


### PR DESCRIPTION
v1.0.0.16 doesn't have the correct opcodes for packet suppression for its uses ; banned as per request of the dev
![image](https://github.com/user-attachments/assets/ec555619-d1d3-425a-b992-a2e8b121a9dd)
