### PR TITLE
Ban Tracky 1.5.5.10 and older

### DIFF
--- a/UIRes/bannedplugin.json
+++ b/UIRes/bannedplugin.json
@@ -372,7 +372,7 @@
   },
   {
     "Name": "TrackyTrack",
-    "AssemblyVersion": "1.5.5.2"
+    "AssemblyVersion": "1.5.5.10"
   },
   {
     "Name": "rtyping",


### PR DESCRIPTION
Gets replaced by 1.5.6.0 <https://github.com/goatcorp/DalamudPluginsD17/pull/5301>

Not any big bug, but people tend to upload with older versions and wrong data sometimes, so a ban to get rid of these versions :)