### PR TITLE
Ban Tracky 1.5.6.0

### DIFF
--- a/UIRes/bannedplugin.json
+++ b/UIRes/bannedplugin.json
@@ -372,7 +372,8 @@
   },
   {
     "Name": "TrackyTrack",
-    "AssemblyVersion": "1.5.5.10"
+    "AssemblyVersion": "1.5.6.0",
+    "Reason": "Uploads invalid data."
   },
   {
     "Name": "rtyping",


### PR DESCRIPTION
Uploads invalid data, so ban it is.
Replaced by <https://github.com/goatcorp/DalamudPluginsD17/pull/5329>