### PR TITLE
Ban Tracky and SubmarineTracker

### DIFF
--- a/UIRes/bannedplugin.json
+++ b/UIRes/bannedplugin.json
@@ -255,7 +255,8 @@
   },
   {
     "Name": "SubmarineTracker",
-    "AssemblyVersion": "1.8.0.7"
+    "AssemblyVersion": "1.9.5.2",
+    "Reason": "Upload server changed."
   },
   {
     "Name": "BlueMageHelper",
@@ -372,8 +373,8 @@
   },
   {
     "Name": "TrackyTrack",
-    "AssemblyVersion": "1.5.6.0",
-    "Reason": "Uploads invalid data."
+    "AssemblyVersion": "1.5.6.2",
+    "Reason": "Upload server changed."
   },
   {
     "Name": "rtyping",


### PR DESCRIPTION
Upload server switched, banning old version to remove them from the pool

Versions getting replaced with
<https://github.com/goatcorp/DalamudPluginsD17/pull/5393>
<https://github.com/goatcorp/DalamudPluginsD17/pull/5394>

