### PR TITLE
Ban Tracky 1.5.9.1

### DIFF
--- a/UIRes/bannedplugin.json
+++ b/UIRes/bannedplugin.json
@@ -374,8 +374,8 @@
   },
   {
     "Name": "TrackyTrack",
-    "AssemblyVersion": "1.5.6.2",
-    "Reason": "Upload server changed."
+    "AssemblyVersion": "1.5.9.1",
+    "Reason": "Prevent faulty uploads."
   },
   {
     "Name": "rtyping",


### PR DESCRIPTION
Faulty uploads to my DB because of a mistake in the hook, so banning it.

Newer version PRed to DP17 under <https://github.com/goatcorp/DalamudPluginsD17/pull/6047>