### PR TITLE
Update bannedplugin.json

### DIFF
--- a/UIRes/bannedplugin.json
+++ b/UIRes/bannedplugin.json
@@ -546,5 +546,10 @@
     "Name": "MiniCactpotSolver",
     "AssemblyVersion": "3.0.0.1",
     "Reason": "Breaking CS change causing per-frame errors."
+  },
+  {
+    "Name": "Mappy",
+    "AssemblyVersion": "3.1.6.8",
+    "Reason": "Has known issues breaking the map. Developers are aware and will investigate/fix when possible."
   }
 ]


### PR DESCRIPTION
Per request of @MidoriKami 

Context:
https://discord.com/channels/581875019861328007/653504487352303619/1415749235290411048

Plugin is currently broken due to a library incompatibility and will render the map unusable. A fix is being looked into.