### PR TITLE
Update bannedplugin.json

### DIFF
--- a/UIRes/bannedplugin.json
+++ b/UIRes/bannedplugin.json
@@ -508,7 +508,7 @@
   },
   {
     "Name": "F5F12CDE900C5A90BA2293DF08A84B4C6055768228E6E0F763A27AC3957BDB6B",
-    "AssemblyVersion": "41.1.0.0"
+    "AssemblyVersion": "47.2.0.0"
   },
   {
     "Name": "InventoryTools",


### PR DESCRIPTION
An old version of my plugin crashes on login.
Cause is the signature of `AtkUnitBase.GetComponentByNodeId` changed and the plugin is running custom CS.
Update was already released.